### PR TITLE
Add view for counters with value >= 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Akka service implementing a named, event-sourced counter with increment/decre
 - Counter value never goes below zero (decrement at zero is rejected)
 - Counter overflows to zero when incremented past Long.MAX_VALUE
 - Counter name can be changed at any time without affecting the value
+- Query all counters whose current value is greater than or equal to 10
 
 ## Prerequisites
 
@@ -53,6 +54,21 @@ curl -X PUT http://localhost:9000/counter/my-counter/name \
 Try decrementing at zero (should return error):
 ```shell
 curl -X POST http://localhost:9000/counter/zero-test/decrement
+```
+
+List all counters whose value is at least 10:
+```shell
+curl http://localhost:9000/counters/at-least-ten
+```
+
+Example response:
+```json
+{
+  "counters": [
+    { "counterId": "my-counter", "name": "My First Counter", "value": 12 },
+    { "counterId": "another",    "name": "",                 "value": 10 }
+  ]
+}
 ```
 
 ## Testing

--- a/specs/5-counters-at-least-ten-view/spec.md
+++ b/specs/5-counters-at-least-ten-view/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: View for Counters with Value >= 10
+
+**Feature Branch**: `claude/write-issue-5-spec-1cMuM`
+**Created**: 2026-04-15
+**Status**: Draft
+**Issue**: octonato/simple-counter#5
+**Input**: User description: "Needs a View for counter for counter >= 10 — The view should return the list of counters that are greater or equal to 10"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List Counters With Value At Least Ten (Priority: P1)
+
+A user queries the system for all counters whose current value is greater than or equal to 10 and receives the list of matching counters (each with its identifier, name and current value).
+
+**Why this priority**: This is the sole functional ask of the issue. Without it, there is no way to discover which counters have crossed the "ten" threshold, and the feature delivers no value.
+
+**Independent Test**: Can be fully tested by creating several counters with varying values (some below 10, some equal to 10, some above 10), querying the view, and verifying the returned list contains exactly the counters whose values are >= 10.
+
+**Acceptance Scenarios**:
+
+1. **Given** counters with values 3, 9, 10, 11 and 42, **When** the user queries the view, **Then** the result contains only the counters with values 10, 11 and 42.
+2. **Given** no counters have ever reached a value of 10, **When** the user queries the view, **Then** the result is an empty list.
+3. **Given** a counter whose value is 10, **When** the counter is decremented to 9, **Then** it no longer appears in the view results.
+4. **Given** a counter whose value is 9, **When** the counter is incremented to 10, **Then** it appears in the view results.
+
+---
+
+### User Story 2 - View Reflects Renames (Priority: P2)
+
+When a counter that qualifies for the view is renamed, the view returns the updated name on the next query.
+
+**Why this priority**: Counters can be renamed at any time (see `specs/1-event-sourced-counter/spec.md`). The view should present the most recent name so callers see consistent information, but the threshold behaviour is the primary concern.
+
+**Independent Test**: Create a counter, increment it to 10 or more, rename it, query the view, and verify the new name is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a counter with value 15 and name "old-name" is present in the view, **When** the user renames it to "new-name", **Then** a subsequent query returns "new-name" for that counter.
+2. **Given** a counter with value 5 and name "below-threshold", **When** the user renames it to "still-below", **Then** the counter is still not present in the view.
+
+---
+
+### Edge Cases
+
+- **Exactly ten**: A counter whose value is exactly 10 is included in the result (the threshold is inclusive).
+- **Overflow to zero**: When a counter overflows from `Long.MAX_VALUE` back to 0, it is removed from the view on the next refresh because 0 < 10.
+- **Decrement across the threshold**: A counter decremented from 10 to 9 is removed from the view.
+- **Increment across the threshold**: A counter incremented from 9 to 10 is added to the view.
+- **Empty result**: If no counters currently satisfy the condition, the view returns an empty list rather than an error.
+- **Empty name**: Counters with an empty name are returned as-is; an empty name is a valid name per the existing spec.
+- **Eventual consistency**: The view is updated asynchronously from the counter events, so there may be a short delay between a counter crossing the threshold and the view reflecting that change.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a query that returns all counters whose current value is greater than or equal to 10.
+- **FR-002**: The query result MUST include, for each matching counter, its identifier, name, and current value.
+- **FR-003**: The view MUST include a counter as soon as its value becomes >= 10 as a result of an increment.
+- **FR-004**: The view MUST exclude a counter as soon as its value drops below 10 (for example, via decrement or overflow to zero).
+- **FR-005**: The view MUST reflect the latest known name of a counter, updating when a counter is renamed.
+- **FR-006**: The view MUST return an empty list when no counters satisfy the condition (not an error).
+- **FR-007**: The query MUST be reachable via an HTTP endpoint so that existing API clients can consume it using the same mechanism as the other counter operations.
+- **FR-008**: The view MUST be built from the existing counter events (`value-incremented`, `value-decremented`, `name-changed`); no new events are required on the counter entity.
+
+### Key Entities
+
+- **Counter (existing)**: Already defined in `specs/1-event-sourced-counter/spec.md`. Identified by a unique ID, has a name and a current value.
+- **CountersAtLeastTen (new, read model row)**: One row per counter that currently has a value >= 10. Attributes: counter ID, name, current value. A counter is absent from the read model when its value is below 10.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can retrieve, in a single request, the list of all counters whose value is >= 10.
+- **SC-002**: The list contains exactly the counters whose latest persisted value is >= 10 — no false positives (counters below 10) and no false negatives (missing counters above 10), allowing for the view's eventual consistency window.
+- **SC-003**: The list reflects the most recent name assigned to each counter.
+- **SC-004**: Crossing the threshold in either direction (up or down) causes the next query to include or exclude the counter accordingly.
+- **SC-005**: The query returns an empty result (not an error) when no counters satisfy the condition.
+
+## Assumptions
+
+- The threshold "10" is fixed and inclusive; it is not configurable by the caller.
+- The view is built from the existing `CounterEntity` event stream and does not require any new events or changes to the counter domain model.
+- Eventual consistency between the counter entity and the view is acceptable.
+- No pagination is required — the number of counters with value >= 10 is expected to be modest. Pagination can be added later if needed.
+- No authentication or authorization is required, consistent with the rest of the service.
+- The query is read-only; there is no way to mutate counters through this view.

--- a/src/main/java/com/example/api/CountersEndpoint.java
+++ b/src/main/java/com/example/api/CountersEndpoint.java
@@ -1,0 +1,35 @@
+package com.example.api;
+
+import akka.javasdk.annotations.Acl;
+import akka.javasdk.annotations.http.Get;
+import akka.javasdk.annotations.http.HttpEndpoint;
+import akka.javasdk.client.ComponentClient;
+import com.example.application.CountersAtLeastTenView;
+
+import java.util.List;
+
+@HttpEndpoint("/counters")
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+public class CountersEndpoint {
+
+  public record CounterSummary(String counterId, String name, long value) {}
+  public record CounterList(List<CounterSummary> counters) {}
+
+  private final ComponentClient componentClient;
+
+  public CountersEndpoint(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+  }
+
+  @Get("/at-least-ten")
+  public CounterList listAtLeastTen() {
+    var result = componentClient
+        .forView()
+        .method(CountersAtLeastTenView::findCountersAtLeastTen)
+        .invoke();
+    var counters = result.items().stream()
+        .map(row -> new CounterSummary(row.counterId(), row.name(), row.value()))
+        .toList();
+    return new CounterList(counters);
+  }
+}

--- a/src/main/java/com/example/application/CountersAtLeastTenView.java
+++ b/src/main/java/com/example/application/CountersAtLeastTenView.java
@@ -1,0 +1,49 @@
+package com.example.application;
+
+import akka.javasdk.annotations.Component;
+import akka.javasdk.annotations.Consume;
+import akka.javasdk.annotations.Query;
+import akka.javasdk.annotations.Table;
+import akka.javasdk.view.TableUpdater;
+import akka.javasdk.view.View;
+import com.example.domain.CounterEvent;
+
+import java.util.List;
+
+@Component(id = "counters-at-least-ten")
+public class CountersAtLeastTenView extends View {
+
+  public record CounterRow(String counterId, String name, long value) {
+    public CounterRow withValue(long newValue) {
+      return new CounterRow(counterId, name, newValue);
+    }
+
+    public CounterRow withName(String newName) {
+      return new CounterRow(counterId, newName, value);
+    }
+  }
+
+  public record CounterRows(List<CounterRow> items) {}
+
+  @Table("counters")
+  @Consume.FromEventSourcedEntity(CounterEntity.class)
+  public static class CountersUpdater extends TableUpdater<CounterRow> {
+    public Effect<CounterRow> onEvent(CounterEvent event) {
+      var counterId = updateContext().eventSubject().orElse("");
+      var current = rowState() != null ? rowState() : new CounterRow(counterId, "", 0);
+      return switch (event) {
+        case CounterEvent.ValueIncremented e ->
+            effects().updateRow(current.withValue(e.newValue()));
+        case CounterEvent.ValueDecremented e ->
+            effects().updateRow(current.withValue(e.newValue()));
+        case CounterEvent.NameChanged e ->
+            effects().updateRow(current.withName(e.newName()));
+      };
+    }
+  }
+
+  @Query("SELECT * AS items FROM counters WHERE value >= 10")
+  public QueryEffect<CounterRows> findCountersAtLeastTen() {
+    return queryResult();
+  }
+}

--- a/src/test/java/com/example/api/CountersEndpointIntegrationTest.java
+++ b/src/test/java/com/example/api/CountersEndpointIntegrationTest.java
@@ -1,0 +1,119 @@
+package com.example.api;
+
+import akka.javasdk.testkit.TestKitSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CountersEndpointIntegrationTest extends TestKitSupport {
+
+  private void increment(String counterId, int times) {
+    for (int i = 0; i < times; i++) {
+      httpClient.POST("/counter/" + counterId + "/increment")
+          .responseBodyAs(CounterEndpoint.CounterResponse.class)
+          .invoke();
+    }
+  }
+
+  private void decrement(String counterId) {
+    httpClient.POST("/counter/" + counterId + "/decrement")
+        .responseBodyAs(CounterEndpoint.CounterResponse.class)
+        .invoke();
+  }
+
+  private void rename(String counterId, String name) {
+    httpClient.PUT("/counter/" + counterId + "/name")
+        .withRequestBody(new CounterEndpoint.ChangeNameRequest(name))
+        .responseBodyAs(CounterEndpoint.CounterResponse.class)
+        .invoke();
+  }
+
+  private CountersEndpoint.CounterList listAtLeastTen() {
+    var response = httpClient.GET("/counters/at-least-ten")
+        .responseBodyAs(CountersEndpoint.CounterList.class)
+        .invoke();
+    assertThat(response.status().isSuccess()).isTrue();
+    return response.body();
+  }
+
+  @Test
+  void shouldReturnQualifyingCountersAndExcludeOthers() {
+    var qualifyingId = "endpoint-qualifies-" + System.nanoTime();
+    var belowId = "endpoint-below-" + System.nanoTime();
+
+    increment(qualifyingId, 10);
+    increment(belowId, 5);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var list = listAtLeastTen();
+          var ids = list.counters().stream()
+              .map(CountersEndpoint.CounterSummary::counterId)
+              .toList();
+          assertThat(ids).contains(qualifyingId);
+          assertThat(ids).doesNotContain(belowId);
+
+          var qualifying = list.counters().stream()
+              .filter(c -> c.counterId().equals(qualifyingId))
+              .findFirst();
+          assertThat(qualifying).isPresent();
+          assertThat(qualifying.get().value()).isEqualTo(10);
+        });
+  }
+
+  @Test
+  void shouldRemoveCounterFromListAfterCrossingBelowThreshold() {
+    var counterId = "endpoint-falling-" + System.nanoTime();
+
+    increment(counterId, 10);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(listAtLeastTen().counters().stream()
+                .map(CountersEndpoint.CounterSummary::counterId))
+                .contains(counterId));
+
+    decrement(counterId);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(listAtLeastTen().counters().stream()
+                .map(CountersEndpoint.CounterSummary::counterId))
+                .doesNotContain(counterId));
+  }
+
+  @Test
+  void shouldReflectRenameInResponse() {
+    var counterId = "endpoint-renamed-" + System.nanoTime();
+
+    increment(counterId, 12);
+    rename(counterId, "my-big-counter");
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var row = listAtLeastTen().counters().stream()
+              .filter(c -> c.counterId().equals(counterId))
+              .findFirst();
+          assertThat(row).isPresent();
+          assertThat(row.get().name()).isEqualTo("my-big-counter");
+          assertThat(row.get().value()).isEqualTo(12);
+        });
+  }
+
+  @Test
+  void shouldReturnSuccessEvenWhenNoCountersQualify() {
+    var response = httpClient.GET("/counters/at-least-ten")
+        .responseBodyAs(CountersEndpoint.CounterList.class)
+        .invoke();
+
+    assertThat(response.status().isSuccess()).isTrue();
+    assertThat(response.body().counters()).isNotNull();
+  }
+}

--- a/src/test/java/com/example/application/CountersAtLeastTenViewIntegrationTest.java
+++ b/src/test/java/com/example/application/CountersAtLeastTenViewIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.example.application;
+
+import akka.javasdk.testkit.TestKit;
+import akka.javasdk.testkit.TestKitSupport;
+import com.example.domain.CounterEvent;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CountersAtLeastTenViewIntegrationTest extends TestKitSupport {
+
+  @Override
+  protected TestKit.Settings testKitSettings() {
+    return TestKit.Settings.DEFAULT
+        .withEventSourcedEntityIncomingMessages(CounterEntity.class);
+  }
+
+  private void setValue(String counterId, long value) {
+    var events = testKit.getEventSourcedEntityIncomingMessages(CounterEntity.class);
+    events.publish(new CounterEvent.ValueIncremented(value), counterId);
+  }
+
+  private void rename(String counterId, String name) {
+    var events = testKit.getEventSourcedEntityIncomingMessages(CounterEntity.class);
+    events.publish(new CounterEvent.NameChanged(name), counterId);
+  }
+
+  private List<CountersAtLeastTenView.CounterRow> query() {
+    return componentClient
+        .forView()
+        .method(CountersAtLeastTenView::findCountersAtLeastTen)
+        .invoke()
+        .items();
+  }
+
+  @Test
+  void shouldReturnOnlyCountersWithValueAtLeastTen() {
+    setValue("c-3", 3);
+    setValue("c-9", 9);
+    setValue("c-10", 10);
+    setValue("c-11", 11);
+    setValue("c-42", 42);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var ids = query().stream().map(CountersAtLeastTenView.CounterRow::counterId).toList();
+          assertThat(ids).containsExactlyInAnyOrder("c-10", "c-11", "c-42");
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoCounterQualifies() {
+    setValue("low-1", 1);
+    setValue("low-2", 5);
+    setValue("low-3", 9);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var ids = query().stream().map(CountersAtLeastTenView.CounterRow::counterId).toList();
+          assertThat(ids).doesNotContain("low-1", "low-2", "low-3");
+        });
+  }
+
+  @Test
+  void shouldIncludeCounterWhenItCrossesThresholdUpwards() {
+    var counterId = "rising";
+    setValue(counterId, 9);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var ids = query().stream().map(CountersAtLeastTenView.CounterRow::counterId).toList();
+          assertThat(ids).doesNotContain(counterId);
+        });
+
+    setValue(counterId, 10);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var row = query().stream()
+              .filter(r -> r.counterId().equals(counterId))
+              .findFirst();
+          assertThat(row).isPresent();
+          assertThat(row.get().value()).isEqualTo(10);
+        });
+  }
+
+  @Test
+  void shouldExcludeCounterWhenItCrossesThresholdDownwards() {
+    var counterId = "falling";
+    setValue(counterId, 10);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(query().stream().map(CountersAtLeastTenView.CounterRow::counterId))
+                .contains(counterId));
+
+    var events = testKit.getEventSourcedEntityIncomingMessages(CounterEntity.class);
+    events.publish(new CounterEvent.ValueDecremented(9), counterId);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(query().stream().map(CountersAtLeastTenView.CounterRow::counterId))
+                .doesNotContain(counterId));
+  }
+
+  @Test
+  void shouldExcludeCounterWhenItOverflowsToZero() {
+    var counterId = "overflowing";
+    setValue(counterId, 100);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(query().stream().map(CountersAtLeastTenView.CounterRow::counterId))
+                .contains(counterId));
+
+    var events = testKit.getEventSourcedEntityIncomingMessages(CounterEntity.class);
+    events.publish(new CounterEvent.ValueIncremented(0), counterId);
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() ->
+            assertThat(query().stream().map(CountersAtLeastTenView.CounterRow::counterId))
+                .doesNotContain(counterId));
+  }
+
+  @Test
+  void shouldReflectRenameForQualifyingCounter() {
+    var counterId = "renamed";
+    setValue(counterId, 15);
+    rename(counterId, "old-name");
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var row = query().stream()
+              .filter(r -> r.counterId().equals(counterId))
+              .findFirst();
+          assertThat(row).isPresent();
+          assertThat(row.get().name()).isEqualTo("old-name");
+        });
+
+    rename(counterId, "new-name");
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          var row = query().stream()
+              .filter(r -> r.counterId().equals(counterId))
+              .findFirst();
+          assertThat(row).isPresent();
+          assertThat(row.get().name()).isEqualTo("new-name");
+        });
+  }
+}


### PR DESCRIPTION
Implements octonato/simple-counter#5 — a read-only view that returns the list of counters whose current value is greater than or equal to 10.

The full specification (user stories, functional requirements, edge cases, success criteria) has been captured directly on octonato/simple-counter#5 and is tracked in this repo under `specs/5-counters-at-least-ten-view/spec.md`.

## Scope

- New `View` that projects the existing `CounterEntity` event stream (`value-incremented`, `value-decremented`, `name-changed`) into a read model of counters with value >= 10.
- New HTTP query endpoint to retrieve the list of matching counters (id, name, current value).
- Integration tests covering the threshold boundary (exactly 10, crossing up, crossing down), rename propagation, overflow-to-zero removal, and the empty-result case.
- No changes to the counter domain model or events — the view is derived entirely from what already exists.

## Out of scope

- Pagination (not needed at current expected volumes).
- A configurable threshold — the threshold is fixed at 10 per the spec.
- Any write path through the view — it is strictly read-only.

## Progress

- [x] Specification written and recorded on the issue and under `specs/5-counters-at-least-ten-view/spec.md`
- [ ] Domain layer (no changes expected)
- [ ] `CountersAtLeastTenView` (application layer)
- [ ] View integration test
- [ ] Endpoint wiring on `CounterEndpoint` (or a dedicated endpoint)
- [ ] Endpoint integration test
- [ ] README updated with a `curl` example

## Test plan

- [ ] `mvn test` passes
- [ ] `mvn verify` passes (unit + integration)
- [ ] Manual `curl` against the new query endpoint returns only counters with value >= 10

https://claude.ai/code/session_01Xsoxi9mQunJdQ7UpdqpHaB